### PR TITLE
2.0 tweak to docs and fix for config

### DIFF
--- a/Controller/Component/SignMeUpComponent.php
+++ b/Controller/Component/SignMeUpComponent.php
@@ -40,7 +40,7 @@ class SignMeUpComponent extends Component {
 	}
 
 	private function __loadConfig() {
-		if (Configure::load('SignMeUp.sign_me_up', 'default', false) === false) {
+		if (Configure::load('sign_me_up', 'default', false) === false) {
 			die('Could not load sign me up config');
 		}
 	}

--- a/readme.markdown
+++ b/readme.markdown
@@ -5,7 +5,7 @@ Sign Me Up is a CakePHP plugin that takes out 99% of the work needed to develop 
 ##Installation
 Install the plugin:
 
-	cd myapp/app/plugins/
+	cd myapp/app/Plugin/
 	git clone git@github.com:voidet/sign_me_up.git sign_me_up
 
 To attach the plugin to a particular model (User/Member/Pimp) simply add in the plugin's component in your chosen controller & model:
@@ -19,7 +19,7 @@ To attach the plugin to a particular model (User/Member/Pimp) simply add in the 
 			parent::beforeFilter();
 		}
 
-And in the User model app/models/user.php
+And in the User model app/Model/User.php
 
 	class User extends AppModel {
 
@@ -41,18 +41,18 @@ Next up create the register, activate & forgotten password methods in your contr
 
 Sign Me Up also comes with 3 elements for your views, which don't have to be used. However in your views feel free to use the elements to create the Registration, Activation and Forgotten Password forms as:
 
-	app/views/users/register.ctp
+	app/View/Users/register.ctp
 		<?php echo $this->element('register', array(), array('plugin' => 'SignMeUp')); ?>
 
-	app/views/users/activate.ctp
+	app/View/Users/activate.ctp
 		<?php echo $this->element('activate', array(), array('plugin' => 'SignMeUp')); ?>
 
-	app/views/users/forgotten_password_.ctp
+	app/View/Users/forgotten_password_.ctp
 		<?php echo $this->element('forgotten_password', array(), array('plugin' => 'SignMeUp')); ?>
 
 Currently Forgotten Passwords are based on the user's email address entered into the form. If there is any request for this to be based on another field I will review.
 
-Next up the plugin requires that you have a config file in 'app/config/sign_me_up.php'. SignMeUp configuration allows you to overwrite all default CakePHP email parameters by simply specifying the elements in the SignMeUp configuration array i.e change email sending to HTML format via setting the sendAs to HTML or change the email layout with 'layout' => 'myLayout'. The only thing that you would need to diverge from the Email Component settings with is the welcome and activate templates. You can set them with welcome_template and activation_template elements:
+Next up the plugin requires that you have a config file in 'app/Config/sign_me_up.php'. SignMeUp configuration allows you to overwrite all default CakePHP email parameters by simply specifying the elements in the SignMeUp configuration array i.e change email sending to HTML format via setting the sendAs to HTML or change the email layout with 'layout' => 'myLayout'. The only thing that you would need to diverge from the Email Component settings with is the welcome and activate templates. You can set them with welcome_template and activation_template elements:
 
 	<?php
 


### PR DESCRIPTION
Working through http://www.jotlab.com/2011/01/29/sign-me-up-a-cakephp-registration-plugin/ it seems not everything is quite right yet for working with Cake 2.0 -- the first things that bit me were the path names in the documentation and sign_me_up insisting on the config being in the plugin directory and not the app directory.

I'm not sure if this is best practice, but looking around the only other example of loading configs I found was at https://github.com/webtechnick/CakePHP-Facebook-Plugin/blob/cakephp2.0/Lib/FacebookInfo.php which does Configure::load('facebook') rather than for example Configure::load('CakePHP-Facebook-Plugin.facebook').
